### PR TITLE
Use investigation name instead of ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /.project
 /.settings/
 /.pydevproject
+package-lock.json
+/src/site/xhtml/installation.html

--- a/src/main/java/org/icatproject/dashboard/exposed/IcatRest.java
+++ b/src/main/java/org/icatproject/dashboard/exposed/IcatRest.java
@@ -48,8 +48,10 @@ import org.icatproject.dashboard.manager.PropsManager;
 import static org.icatproject.dashboard.utility.DateUtility.convertToLocalDate;
 import static org.icatproject.dashboard.utility.DateUtility.convertToLocalDateTime;
 import static org.icatproject.dashboard.utility.RestUtility.createPrePopulatedLongMap;
+import org.icatproject.icat.client.IcatException;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
+import org.json.simple.parser.ParseException;
 import org.slf4j.LoggerFactory;
 
 @Stateless
@@ -578,10 +580,20 @@ public class IcatRest {
         
         for(Object[] investigation: result){
             JSONObject obj = new JSONObject();
-            obj.put("investigationId",investigation[0]);
             obj.put("value",investigation[1]);
-            resultArray.add(obj);
             
+            try {
+                // Attempt to retrieve the investigation name from ICAT
+                String name = icatData.getInvestigationNameById((long)investigation[0]);
+                obj.put("investigationId", name);
+            } catch (IcatException | ParseException ex) {
+                // If the name can't be retrieved then use the ID instead
+                obj.put("investigationId", investigation[0]);
+                LOG.warn("Unable to retrieve investigation name from ICAT, using ID instead : " 
+                        + ex.getMessage());
+            }
+            
+            resultArray.add(obj);
         }
         
         return resultArray.toJSONString();

--- a/src/main/java/org/icatproject/dashboard/exposed/IcatRest.java
+++ b/src/main/java/org/icatproject/dashboard/exposed/IcatRest.java
@@ -37,6 +37,7 @@ import org.icatproject.dashboard.exceptions.BadRequestException;
 import org.icatproject.dashboard.exceptions.DashboardException;
 import org.icatproject.dashboard.exceptions.GetLocationException;
 import org.icatproject.dashboard.exceptions.InternalException;
+import org.icatproject.dashboard.exceptions.NotFoundException;
 import static org.icatproject.dashboard.exposed.PredicateCreater.getDatePredicate;
 import static org.icatproject.dashboard.exposed.PredicateCreater.getEntityCountPredicate;
 import static org.icatproject.dashboard.exposed.PredicateCreater.getInstrumentPredicate;
@@ -586,7 +587,7 @@ public class IcatRest {
                 // Attempt to retrieve the investigation name from ICAT
                 String name = icatData.getInvestigationNameById((long)investigation[0]);
                 obj.put("investigationId", name);
-            } catch (IcatException | ParseException ex) {
+            } catch (IcatException | ParseException | NotFoundException ex) {
                 // If the name can't be retrieved then use the ID instead
                 obj.put("investigationId", investigation[0]);
                 LOG.warn("Unable to retrieve investigation name from ICAT, using ID instead : " 

--- a/src/main/java/org/icatproject/dashboard/manager/IcatDataManager.java
+++ b/src/main/java/org/icatproject/dashboard/manager/IcatDataManager.java
@@ -274,6 +274,20 @@ public class IcatDataManager {
     }
     
     /**
+     * Retrieves the name of an investigation from ICAT.
+     * @param id Investigation ID
+     * @return Investigation name
+     */
+    public String getInvestigationNameById(long id) throws IcatException, ParseException {
+        String queryResult = restSession.search("SELECT i.name FROM Investigation i WHERE i.id=" + id);
+        
+        JSONParser parser = new JSONParser();
+        JSONArray resultArray = (JSONArray) parser.parse(queryResult);
+        
+        return (String) resultArray.get(0);
+    }
+    
+    /**
      * Creates an ICAT RestFul client.
      * @param properties that contain the login details.
      * @return a ICAT RestFul client.

--- a/src/main/java/org/icatproject/dashboard/manager/IcatDataManager.java
+++ b/src/main/java/org/icatproject/dashboard/manager/IcatDataManager.java
@@ -47,6 +47,7 @@ import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
+import org.icatproject.dashboard.exceptions.NotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -278,11 +279,14 @@ public class IcatDataManager {
      * @param id Investigation ID
      * @return Investigation name
      */
-    public String getInvestigationNameById(long id) throws IcatException, ParseException {
+    public String getInvestigationNameById(long id) throws IcatException, ParseException, NotFoundException {
         String queryResult = restSession.search("SELECT i.name FROM Investigation i WHERE i.id=" + id);
         
         JSONParser parser = new JSONParser();
         JSONArray resultArray = (JSONArray) parser.parse(queryResult);
+        if (resultArray.isEmpty()) {
+            throw new NotFoundException("Couldn't find investigation in ICAT by ID : " + id);
+        }
         
         return (String) resultArray.get(0);
     }


### PR DESCRIPTION
Charts that give details for investigations are now labelled with the investigation name instead of ID.

Fixes #93 